### PR TITLE
Adiciona modulo Terraform artifact-registry e cria repo "aplication"

### DIFF
--- a/infra/environments/production/main.tf
+++ b/infra/environments/production/main.tf
@@ -5,3 +5,10 @@ module "cloud_run" {
   service_name = var.service_name
   image        = var.image
 }
+
+module "artifact_registry" {
+  source = "../../modules/artifact-registry"
+
+  project_id    = var.project_id
+  repository_id = "aplication"
+}

--- a/infra/modules/artifact-registry/.terraform.lock.hcl
+++ b/infra/modules/artifact-registry/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.39.0"
+  constraints = ">= 6.0.0, < 8.0.0"
+  hashes = [
+    "h1:n6fal0gOUI1IbFMFwITnhmqA7453sWeqS229XqpXAB4=",
+    "zh:00eea2ae6d24e580a107574e3a93fcace52e2f1d912c3f7d1cdeadd9f0449443",
+    "zh:3b626035e0ea3ec8aa0720cd976cda6f252645cfa90253d5d3b087c56a74d514",
+    "zh:42505c5304e30208a30edb62385cca4f5f648a38f386158f86b39d39516d59c1",
+    "zh:97b1959fc2c5f39db12ee7a8929227efd004bc389935f893d4a3e4fb48713c72",
+    "zh:9d4ccd2f4f0c89affabd07ab3ec6ddfae1de5ee9633cc3233a5dc63980ca89ca",
+    "zh:9e1dccb6efff92b2221c68ab00dbe82e184a48aeb5f21392ada4767ac64cd08e",
+    "zh:b752408bb4d9693565526eeb73986e5cbc8626acd906df49eef0cdd7e13cac14",
+    "zh:d3eea63e3b58ba564d6a3065f839cde790ddf091501f931fe08002133797b0a3",
+    "zh:eb1f9fc07e7a1d23d64194534d03ff43e0f95bd2f65a7286ed247290461d3dfc",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f9bf75d75117a1da609042a2ee63a8fab31b6206c93260da3fc343bd67453f97",
+    "zh:ff18322b786ad6216ee3aebb02e6374223eaa16b5f181109089786128718afc3",
+  ]
+}

--- a/infra/modules/artifact-registry/main.tf
+++ b/infra/modules/artifact-registry/main.tf
@@ -1,0 +1,7 @@
+resource "google_artifact_registry_repository" "this" {
+  project       = var.project_id
+  location      = var.location
+  repository_id = var.repository_id
+  description   = var.description
+  format        = "DOCKER"
+}

--- a/infra/modules/artifact-registry/outputs.tf
+++ b/infra/modules/artifact-registry/outputs.tf
@@ -1,0 +1,9 @@
+output "repository_id" {
+  description = "Last part of the repository name."
+  value       = google_artifact_registry_repository.this.repository_id
+}
+
+output "name" {
+  description = "Full resource name of the repository."
+  value       = google_artifact_registry_repository.this.name
+}

--- a/infra/modules/artifact-registry/variables.tf
+++ b/infra/modules/artifact-registry/variables.tf
@@ -1,0 +1,21 @@
+variable "project_id" {
+  description = "GCP project where the repository is created."
+  type        = string
+}
+
+variable "repository_id" {
+  description = "Last part of the repository name (e.g. \"aplication\")."
+  type        = string
+}
+
+variable "location" {
+  description = "Location of the repository."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "description" {
+  description = "Description of the repository."
+  type        = string
+  default     = ""
+}

--- a/infra/modules/artifact-registry/versions.tf
+++ b/infra/modules/artifact-registry/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0, < 8.0"
+    }
+  }
+}


### PR DESCRIPTION
Cria infra/modules/artifact-registry (google_artifact_registry_repository, formato DOCKER) e instancia em infra/environments/production com repository_id = "aplication", mesmo nome que .github/workflows/deploy-gcp.yml ja usa no path de push da imagem (que hoje aponta pra um repo inexistente).

Nao rodei terraform apply/plan reais.