### PR TITLE
Migra deploy-gcp.yml para WIF e usa repo guia-prod no Artifact Registry

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -7,39 +7,51 @@ on:
       - main
       - staging
 jobs:
-    deploy:
-        if: ${{ github.event.pull_request.merged == true }}
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v4
-            - name: Autenticate to GCP
-              uses: google-github-actions/auth@v2
-              with:
-                  credentials_json: ${{ secrets.GCP_SA_KEY }}
-            - name: Configurar Google Cloud SDK
-              uses: google-github-actions/setup-gcloud@v2
-            - name: Configurar Docker para Artifact Registry
-              run: gcloud auth configure-docker us-central1-docker.pkg.dev
-            - name: Definir variáveis de ambiente
-              run: |
-                if [[ "${{ github.base_ref }}" == "main" ]]; then
-                  echo "BRANCH=main" >> $GITHUB_ENV
-                  echo "SERVICE_NAME=guia-prod" >> $GITHUB_ENV
-                else
-                  echo "BRANCH=staging" >> $GITHUB_ENV
-                  echo "SERVICE_NAME=guia-staging" >> $GITHUB_ENV
-                fi
-            - name: Build da Imagem Docker
-              run: |
-                docker build -t us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/aplication/${{ env.SERVICE_NAME }}:${{ github.sha }} .
-            - name: Deploy da Imagem Docker
-              run: |
-                docker push us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/aplication/${{ env.SERVICE_NAME }}:${{ github.sha }}
-            - name: Deploy para o Cloud Run
-              run: |
-                gcloud run deploy ${{ env.SERVICE_NAME }} \
-                  --image us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/aplication/${{ env.SERVICE_NAME }}:${{ github.sha }} \
-                  --region us-central1 \
-                  --platform managed \
-                  --allow-unauthenticated
+  deploy:
+    if: ${{ github.event.pull_request.merged == true }}
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: read
+      id-token: write # necessario para o token OIDC do Workload Identity Federation
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Autenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_PROD_WIF_PROVIDER }}
+          service_account: ${{ vars.GCP_PROD_SA_EMAIL }}
+
+      - name: Configurar Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configurar Docker para Artifact Registry
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev
+
+      - name: Definir variáveis de ambiente
+        run: |
+          if [[ "${{ github.base_ref }}" == "main" ]]; then
+            echo "BRANCH=main" >> $GITHUB_ENV
+            echo "SERVICE_NAME=guia-prod" >> $GITHUB_ENV
+          else
+            echo "BRANCH=staging" >> $GITHUB_ENV
+            echo "SERVICE_NAME=guia-staging" >> $GITHUB_ENV
+          fi
+
+      - name: Build da Imagem Docker
+        run: |
+          docker build -t us-central1-docker.pkg.dev/${{ vars.GCP_PROD_PROJECT }}/guia-prod/${{ env.SERVICE_NAME }}:${{ github.sha }} .
+
+      - name: Deploy da Imagem Docker
+        run: |
+          docker push us-central1-docker.pkg.dev/${{ vars.GCP_PROD_PROJECT }}/guia-prod/${{ env.SERVICE_NAME }}:${{ github.sha }}
+
+      - name: Deploy para o Cloud Run
+        run: |
+          gcloud run deploy ${{ env.SERVICE_NAME }} \
+            --image us-central1-docker.pkg.dev/${{ vars.GCP_PROD_PROJECT }}/guia-prod/${{ env.SERVICE_NAME }}:${{ github.sha }} \
+            --region us-central1 \
+            --platform managed \
+            --allow-unauthenticated

--- a/infra/environments/production/main.tf
+++ b/infra/environments/production/main.tf
@@ -10,5 +10,5 @@ module "artifact_registry" {
   source = "../../modules/artifact-registry"
 
   project_id    = var.project_id
-  repository_id = "aplication"
+  repository_id = "guia-prod"
 }


### PR DESCRIPTION
A SA por tras de secrets.GCP_SA_KEY nao tinha permissao de escrita no Artifact Registry (artifactregistry.repositories.uploadArtifacts denied). Troca para Workload Identity Federation com a mesma SA github-actions-ci usada em infra-terraform.yml (ja tem roles/editor no projeto), via vars.GCP_PROD_WIF_PROVIDER / vars.GCP_PROD_SA_EMAIL / vars.GCP_PROD_PROJECT (GitHub Environment "production").

Path da imagem trocado de aplication/ para guia-prod/, alinhado com infra/environments/production/main.tf (repository_id = "guia-prod" no modulo artifact-registry).